### PR TITLE
TagAPI is compatible as of version 1.7

### DIFF
--- a/ProtocolLib/src/com/comphenix/protocol/ProtocolLibrary.java
+++ b/ProtocolLib/src/com/comphenix/protocol/ProtocolLibrary.java
@@ -71,7 +71,7 @@ public class ProtocolLibrary extends JavaPlugin {
 	
 	private void checkForIncompatibility(PluginManager manager) {
 		// Plugin authors: Notify me to remove these
-		String[] incompatiblePlugins = { "TagAPI" };
+		String[] incompatiblePlugins = {};
 		
 		for (String plugin : incompatiblePlugins) {
 			if (manager.getPlugin(plugin) != null) {

--- a/Readme.md
+++ b/Readme.md
@@ -129,5 +129,3 @@ types. It's remarkably consistent across different versions.
 ### Incompatiblity
 
 The following plugins (to be expanded) are not compatible with ProtocolLib:
-
- * TagAPI


### PR DESCRIPTION
Pushing 1.7 shortly.
