### PR TITLE
Default to Java 7

### DIFF
--- a/ProtocolLib/.classpath
+++ b/ProtocolLib/.classpath
@@ -18,7 +18,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JDK 1.7">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>


### PR DESCRIPTION
Otherwise System.lineSeparator() will fail to compile in TimingReportGenerator.java.

Alternatively you could use System.getProperty("line.separator") in there?!
