### PR TITLE
Stay backwards compatible to Java 6 in test classes

### DIFF
--- a/ProtocolLib/src/test/java/com/comphenix/integration/protocol/SimpleMinecraftClient.java
+++ b/ProtocolLib/src/test/java/com/comphenix/integration/protocol/SimpleMinecraftClient.java
@@ -70,7 +70,7 @@ public class SimpleMinecraftClient {
             // For 1.6
             if (version.compareTo(new MinecraftVersion(PLUGIN_MESSAGE_VERSION)) >= 0) {
                 DataOutputStream data = new DataOutputStream(output);
-            	String host = address.getHostString();
+            	String host = address.getHostName();
 
             	data.writeByte(0xFA);
             	writeString(data, "MC|PingHost");


### PR DESCRIPTION
(getHostString() is available but protected in Java 6)

We could still use this function with Java 6 using reflection, but that would be overkill for tests only ;-)
