### PR TITLE
Fix ConcurrentPlayerMap to use SafeCacheBuilder

### DIFF
--- a/ProtocolLib/src/main/java/com/comphenix/protocol/concurrency/ConcurrentPlayerMap.java
+++ b/ProtocolLib/src/main/java/com/comphenix/protocol/concurrency/ConcurrentPlayerMap.java
@@ -8,12 +8,11 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 
+import com.comphenix.protocol.utility.SafeCacheBuilder;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import com.google.common.base.Function;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
@@ -62,8 +61,8 @@ public class ConcurrentPlayerMap<TValue> extends AbstractMap<Player, TValue> imp
 	/**
 	 * A cache of the associated keys for each player.
 	 */
-	protected Cache<Object, Player> keyLookup = createKeyCache();
 	
+	protected ConcurrentMap<Object, Player> keyLookup = createKeyCache();
 	/**
 	 * The method used to retrieve a unique key for a player.
 	 */
@@ -115,9 +114,9 @@ public class ConcurrentPlayerMap<TValue> extends AbstractMap<Player, TValue> imp
 	 * Construct a cache of keys and the associated player.
 	 * @return The key map.
 	 */
-	protected Cache<Object, Player> createKeyCache() {
-		return CacheBuilder.newBuilder().
-			weakValues(). 
+	protected ConcurrentMap<Object, Player> createKeyCache() {
+		return SafeCacheBuilder.newBuilder().
+			weakValues().
 			removalListener(
 			  new RemovalListener<Object, Player>() {
 				@Override
@@ -154,7 +153,7 @@ public class ConcurrentPlayerMap<TValue> extends AbstractMap<Player, TValue> imp
 		
 		if (newPlayer != null) {
 			// Update the reference
-			keyLookup.asMap().put(key, newPlayer);
+			keyLookup.put(key, newPlayer);
 		} else {
 			valueLookup.remove(key);
 		}
@@ -183,8 +182,6 @@ public class ConcurrentPlayerMap<TValue> extends AbstractMap<Player, TValue> imp
 	protected Player lookupPlayer(Object key) {
 		try {
 			return keyLookup.get(key);
-		} catch (ExecutionException e) {
-			return null;
 		} catch (UncheckedExecutionException e) {
 			return null;
 		}
@@ -198,7 +195,7 @@ public class ConcurrentPlayerMap<TValue> extends AbstractMap<Player, TValue> imp
 	protected Object cachePlayerKey(Player player) {
 		Object key = keyMethod.apply(player);
 		
-		keyLookup.asMap().put(key, player);
+		keyLookup.put(key, player);
 		return key;
 	}
 	
@@ -228,7 +225,7 @@ public class ConcurrentPlayerMap<TValue> extends AbstractMap<Player, TValue> imp
 			Object playerKey = keyMethod.apply((Player) key);
 			TValue value = valueLookup.remove(playerKey);
 			
-			keyLookup.asMap().remove(playerKey);
+			keyLookup.remove(playerKey);
 			return value;
 		}
 		return null;
@@ -240,7 +237,7 @@ public class ConcurrentPlayerMap<TValue> extends AbstractMap<Player, TValue> imp
 			Object playerKey = keyMethod.apply((Player) key);
 			
 			if (valueLookup.remove(playerKey, value)) {
-				keyLookup.asMap().remove(playerKey);
+				keyLookup.remove(playerKey);
 				return true;
 			}
 		}
@@ -277,7 +274,7 @@ public class ConcurrentPlayerMap<TValue> extends AbstractMap<Player, TValue> imp
 			@Override
 			public void clear() {
 				valueLookup.clear();
-				keyLookup.invalidateAll();
+				keyLookup.clear();
 			}
 		};
 	}
@@ -300,7 +297,7 @@ public class ConcurrentPlayerMap<TValue> extends AbstractMap<Player, TValue> imp
 					if (player == null) {
 						// Remove entries that cannot be found
 						source.remove();
-						keyLookup.asMap().remove(entry.getKey());
+						keyLookup.remove(entry.getKey());
 					} else {
 						return new SimpleEntry<Player, TValue>(player, entry.getValue());
 					}

--- a/ProtocolLib/src/main/java/com/comphenix/protocol/utility/SafeCacheBuilder.java
+++ b/ProtocolLib/src/main/java/com/comphenix/protocol/utility/SafeCacheBuilder.java
@@ -199,7 +199,7 @@ public class SafeCacheBuilder<K, V> {
 	 * @throws IllegalStateException if a removal listener was already set
 	 */
 	@SuppressWarnings("unchecked")
-	public <K1 extends K, V1 extends V> SafeCacheBuilder<K1, V1> removalListener(RemovalListener<? super K, ? super V> listener) {
+	public <K1 extends K, V1 extends V> SafeCacheBuilder<K1, V1> removalListener(RemovalListener<? super K1, ? super V1> listener) {
 		builder.removalListener(listener);
 		return (SafeCacheBuilder<K1, V1>) this;
 	}


### PR DESCRIPTION
This fixes support for SportBukkit. There also appears to be another issue with `onPacketReceiving` in SportBukkit causing disconnect on event call but still investigating.
