### PR TITLE
Allow setting the Base64 encoded favicon directly.

### DIFF
--- a/ProtocolLib/src/main/java/com/comphenix/protocol/wrappers/WrappedServerPing.java
+++ b/ProtocolLib/src/main/java/com/comphenix/protocol/wrappers/WrappedServerPing.java
@@ -137,8 +137,16 @@ public class WrappedServerPing extends AbstractWrapper {
 	 * @param image - the new compressed image.
 	 */
 	public void setFavicon(CompressedImage image) {
-		FAVICON.set(handle, image.toEncodedText());
+		setFavicon(image.toEncodedText());
 	}
+
+    /**
+     * Set the Base64 encoded PNG file that is being displayed.
+     * @param encodedImage - The new compressed image, encoded in valid Base64 format.
+     */
+    public void setFavicon(String encodedImage) {
+        FAVICON.set(handle, encodedImage);
+    }
 	
 	/**
 	 * Retrieve the displayed number of online players.


### PR DESCRIPTION
At the moment, there's no way to set the favicon directly with a Base64 encoded PNG file without decoding and encoding it again first. This will add a new method which allow setting the plain Base64 encoded PNG file.
