### PR TITLE
Correctly handle wrapped server pings with no favicon.

### DIFF
--- a/ProtocolLib/src/main/java/com/comphenix/protocol/wrappers/WrappedServerPing.java
+++ b/ProtocolLib/src/main/java/com/comphenix/protocol/wrappers/WrappedServerPing.java
@@ -145,18 +145,19 @@ public class WrappedServerPing extends AbstractWrapper {
 	
 	/**
 	 * Retrieve the compressed PNG file that is being displayed as a favicon.
-	 * @return The favicon.
+	 * @return The favicon, or NULL if no favicon will be displayed.
 	 */
 	public CompressedImage getFavicon() {
-		return CompressedImage.fromEncodedText((String) FAVICON.get(handle));
+		String favicon = (String) FAVICON.get(handle);
+		return (favicon != null) ? CompressedImage.fromEncodedText(favicon) : null;
 	}
 	
 	/**
 	 * Set the compressed PNG file that is being displayed.
-	 * @param image - the new compressed image.
+	 * @param image - the new compressed image or NULL if no favicon should be displayed.
 	 */
 	public void setFavicon(CompressedImage image) {
-		FAVICON.set(handle, image.toEncodedText());
+		FAVICON.set(handle, (image != null) ? image.toEncodedText() : null);
 	}
 	
 	/**
@@ -455,7 +456,7 @@ public class WrappedServerPing extends AbstractWrapper {
 	 */
 	private static class EncodedCompressedImage extends CompressedImage {
 		public EncodedCompressedImage(String encoded) {
-			this.encoded =  encoded;
+			this.encoded =  Preconditions.checkNotNull(encoded, "encoded favicon cannot be NULL");
 		}
 		
 		/**


### PR DESCRIPTION
In the current ProtocolLib release (3.1.0) the `getFavicon()` method will throw a NullPointerException if the server is not sending a favicon. This was partly fixed in 3c5482f but there's still no way of checking if the server is sending a favicon, without checking if the encoded output of the `CompressedImage.toEncodedText()` will return a valid result.

This pull request will make the favicon getter and setter in the server ping correctly handle pings with no favicon, by returning null for `getFavicon()` (if no favicon will be displayed) and allowing to hide the favicon by setting the favicon to null.
