### PR TITLE
Correctly modify player sample with hidden player counts.

### DIFF
--- a/ProtocolLib/src/main/java/com/comphenix/protocol/wrappers/WrappedServerPing.java
+++ b/ProtocolLib/src/main/java/com/comphenix/protocol/wrappers/WrappedServerPing.java
@@ -246,7 +246,10 @@ public class WrappedServerPing extends AbstractWrapper {
 	public ImmutableList<WrappedGameProfile> getPlayers() {
 		if (players == null)
 			return ImmutableList.of();
-		return ImmutableList.copyOf(PROFILE_CONVERT.getSpecific(PLAYERS_PROFILES.get(players)));
+		Object playerProfiles = PLAYERS_PROFILES.get(players);
+		if (playerProfiles == null)
+			return ImmutableList.of();
+		return ImmutableList.copyOf(PROFILE_CONVERT.getSpecific(playerProfiles));
 	}
 	
 	/**
@@ -256,7 +259,7 @@ public class WrappedServerPing extends AbstractWrapper {
 	public void setPlayers(Iterable<? extends WrappedGameProfile> profile) {
 		if (players == null)
 			resetPlayers();
-		PLAYERS_PROFILES.set(players, PROFILE_CONVERT.getGeneric(GameProfile[].class, profile));
+		PLAYERS_PROFILES.set(players, (profile != null) ? PROFILE_CONVERT.getGeneric(GameProfile[].class, profile) : null);
 	}
 	
 	/**


### PR DESCRIPTION
At the moment the `setPlayers()` method will throw a `NullPointerException` if the player count has been hidden. This will correctly reset the player counts before setting the player list and return null in the getter instead of throwing an exception.
