### PR TITLE
Fix NPE in WrappedGameProfile.getId()

### DIFF
--- a/ProtocolLib/src/main/java/com/comphenix/protocol/wrappers/WrappedGameProfile.java
+++ b/ProtocolLib/src/main/java/com/comphenix/protocol/wrappers/WrappedGameProfile.java
@@ -87,7 +87,7 @@ public class WrappedGameProfile extends AbstractWrapper {
 	 * @return The UUID of the player, or NULL if not computed.
 	 */
 	public String getId() {
-		if (GET_UUID_STRING == null)
+		if (GET_UUID_STRING != null)
 			return (String) GET_UUID_STRING.get(handle);
 		return getProfile().getId() != null ? getProfile().getId().toString() : null;
 	}


### PR DESCRIPTION
In the current version 3.3.1-SNAPSHOT version of ProtocolLib a NullPointerException is thrown when calling the getId method of WrappedGameProfile using Spigot-1402 (MC 1.7.8).
I'm assuming that was just a typo.
 If I'm wrong and there was another reason, feel free to correct me.
