### PR TITLE
Minor improvements to ClassLoader

### DIFF
--- a/ProtocolLib/src/main/java/com/comphenix/protocol/utility/ClassSource.java
+++ b/ProtocolLib/src/main/java/com/comphenix/protocol/utility/ClassSource.java
@@ -77,13 +77,13 @@ public abstract class ClassSource {
 			return ClassSource.empty();
 		}
 		
-		ClassSource source = sources[0];
-		for(int i = 1; i < sources.length; i++){
-			if(source == null || sources[i] == null){
+		ClassSource source = null;
+		for(int i = 0; i < sources.length; i++){
+			if(sources[i] == null){
 				throw new IllegalArgumentException("Null values are not permitted as ClassSources.");
 			}
 			
-			source = source.retry(sources[i]);
+			source = source == null ? sources[i] : source.retry(sources[i]);
 		}
 		return source;
 	}


### PR DESCRIPTION
This PR attempts to improve `ClassLoader` by making the following changes:
- `ClassLoader.fromMap` will now throw a `ClassNotFoundException` instead of returning `null` when a class is not found in the map. This behavior is documented.
- Added a static `ClassLoader.attemptLoadFrom` method as an alternative to chaining `retry` calls. This method disallows null values.
- Added a factory method `ClassLoader.empty` method which will never successfully load a class.
- The documentation for `loadClass(String)` now specifies that `null` should not be returned (and instead an exception should be thrown).
