### PR TITLE
Specify provided scope in Maven example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -54,6 +54,7 @@ You can also add ProtocolLib as a Maven dependency:
     <groupId>com.comphenix.protocol</groupId>
     <artifactId>ProtocolLib-API</artifactId>
     <version>4.4.0</version>
+    <scope>provided</scope>
   </dependency>
 </dependencies>
 ````


### PR DESCRIPTION
When this scope isn't set, Apache Maven will include the API into the final JAR file, which creates unnecessarily large file sizes.

The reason I think this behavior is intended, is because the ProtocolLib plugin needs to be installed on the same server as the plugin including ProtocolLib as a dependency in order for ProtocolLib to function. Beside that, the Gradle example specifies the `compileOnly` option which is essentially the same as the `provided` scope in Apache Maven.