### PR TITLE
Fixed protocol injection with latest netty on minecraft 1.11 and below

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.2.1</version>
+				<version>3.2.3</version>
 				<executions>
 					<execution>
 						<phase>package</phase>

--- a/src/main/java/com/comphenix/protocol/ProtocolLib.java
+++ b/src/main/java/com/comphenix/protocol/ProtocolLib.java
@@ -26,6 +26,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.comphenix.protocol.utility.NettyVersion;
 import org.bukkit.Server;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.PluginCommand;
@@ -185,7 +186,11 @@ public class ProtocolLib extends JavaPlugin {
 		// Print the state of the debug mode
 		if (config.isDebug()) {
 			logger.warning("Debug mode is enabled!");
+			logger.info("Detected netty version: " + NettyVersion.getVersion());
+		} else {
+			NettyVersion.getVersion(); // this will cache the version
 		}
+
 		// And the state of the error reporter
 		if (config.isDetailedErrorReporting()) {
 			detailedReporter.setDetailedReporting(true);

--- a/src/main/java/com/comphenix/protocol/injector/netty/ProtocolInjector.java
+++ b/src/main/java/com/comphenix/protocol/injector/netty/ProtocolInjector.java
@@ -25,6 +25,7 @@ import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Set;
 
+import com.comphenix.protocol.utility.NettyVersion;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
@@ -148,9 +149,13 @@ public class ProtocolInjector implements ChannelListener {
 				protected void initChannel(final Channel channel) throws Exception {
 					try {
 						synchronized (networkManagers) {
-							// For some reason it needs to be delayed on 1.12, but the delay breaks 1.11 and below
+							// For some reason it needs to be delayed when using netty 4.1.24 (minecraft  1.12) or newer,
+							// but the delay breaks older minecraft versions
 							// TODO I see this more as a temporary hotfix than a permanent solution
-							if (MinecraftVersion.getCurrentVersion().getMinor() >= 12) {
+							// Check if the netty version is greater than 4.1.24, that's the version bundled with spigot 1.12
+							NettyVersion ver = NettyVersion.getVersion();
+							if ((ver.isValid() && ver.isGreaterThan(4,1,24)) ||
+									MinecraftVersion.getCurrentVersion().getMinor() >= 12) { // fallback if netty version couldn't be detected
 								channel.eventLoop().submit(() ->
 									injectionFactory.fromChannel(channel, ProtocolInjector.this, playerFactory).inject());
 							} else {

--- a/src/main/java/com/comphenix/protocol/utility/NettyVersion.java
+++ b/src/main/java/com/comphenix/protocol/utility/NettyVersion.java
@@ -1,0 +1,83 @@
+package com.comphenix.protocol.utility;
+
+import com.comphenix.protocol.ProtocolLibrary;
+import io.netty.util.Version;
+
+import java.util.Map;
+
+public class NettyVersion {
+    private final static String NETTY_ARTIFACT_ID = "netty-common";
+    private static NettyVersion version;
+
+    public static NettyVersion getVersion() {
+        if(version == null) {
+            version = detectVersion();
+        }
+        return version;
+    }
+
+    private static NettyVersion detectVersion() {
+        Map<String, Version> nettyArtifacts = Version.identify();
+        Version version = nettyArtifacts.get(NETTY_ARTIFACT_ID);
+        if(version != null) {
+            return new NettyVersion(version.artifactVersion());
+        }
+        return new NettyVersion(null);
+    }
+
+    private boolean valid = false;
+    private int major, minor, revision;
+
+    public NettyVersion(String s) {
+        if(s == null) {
+            return;
+        }
+        String[] split = s.split( "\\.");
+        try {
+            this.major = Integer.parseInt(split[0]);
+            this.minor = Integer.parseInt(split[1]);
+            this.revision = Integer.parseInt(split[2]);
+            this.valid = true;
+        } catch (Throwable t) {
+            ProtocolLibrary.getPlugin().getLogger().warning("Could not detect netty version: '" + s + "'");
+        }
+    }
+
+    @Override
+    public String toString() {
+        if(!valid) {
+            return "(invalid)";
+        }
+        return major + "." + minor + "." + revision;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(!(obj instanceof NettyVersion)) {
+            return false;
+        }
+        NettyVersion v = (NettyVersion) obj;
+        return v.major == major && v.minor == minor && v.revision == revision;
+    }
+
+    public int getMajor() {
+        return major;
+    }
+
+    public int getMinor() {
+        return minor;
+    }
+
+    public int getRevision() {
+        return revision;
+    }
+
+    public boolean isValid() {
+        return this.valid;
+    }
+
+    public boolean isGreaterThan(int major, int minor, int rev) {
+        return this.major > major || this.minor > minor || this.revision > rev;
+    }
+
+}


### PR DESCRIPTION
Injection is forced to be delayed since Minecraft 1.12+. This has been hotfixed in https://github.com/dmulloy2/ProtocolLib/commit/b4f9c501b3dd33ff740b917c6ba83cfb99977e61. 

Unfortunately, I still need to stick to spigot 1.8.8. We currently try to update to Java 14, which is not supported by spigot 1.8.8 because the netty version is incompatible. 
After updating the bundled Netty version to 4.1.49 (yeah, I know it's hacky af), I realized that ProtocolLib was not working anymore ("Unable to find NetworkManager in .."). Thus, I added a delay of the injection if a newer Netty version is present.